### PR TITLE
Fixing a typo (missing comma) in the bower.json file

### DIFF
--- a/marco_site/static/bower.json
+++ b/marco_site/static/bower.json
@@ -15,7 +15,7 @@
     "bootstrap3-typeahead": "~3.1.0",
     "jquery-ui": "~1.11.2",
     "lodash": "~2.4.1",
-    "jquery-migrate": "~1.2.1"
+    "jquery-migrate": "~1.2.1",
     "ol3-unofficial": "~3.0.3"
   }
 }


### PR DESCRIPTION
@edrex 
I just noticed this when gulp crapped out after I pulled.
Dunno when it happened.
