### PR TITLE
POR-214 fix 500 error on subpage not found

### DIFF
--- a/portal/data_gaps/models.py
+++ b/portal/data_gaps/models.py
@@ -7,7 +7,7 @@ from portal.base.models import PageBase,DetailPageBase
 class DataGaps(PageBase):
     subpage_types = ['DataGap']
 
-    def get_children(self):
+    def get_detail_children(self):
         return DataGap.objects.child_of(self)
 
 class DataGap(DetailPageBase):

--- a/portal/data_gaps/templates/data_gaps/data_gaps.html
+++ b/portal/data_gaps/templates/data_gaps/data_gaps.html
@@ -1,5 +1,5 @@
 {% extends "cms/section.html" %}
 
 {% block content %}
-	{% include "portal/components/index_listing.html" with items=self.get_children.live item_template="data_gaps/data_gap_card.html" only %}
+	{% include "portal/components/index_listing.html" with items=self.get_detail_children.live item_template="data_gaps/data_gap_card.html" only %}
 {% endblock %}

--- a/portal/ocean_stories/models.py
+++ b/portal/ocean_stories/models.py
@@ -79,7 +79,7 @@ class OceanStorySection(Orderable, OceanStorySectionBase):
 class OceanStories(PageBase):
     subpage_types = ['OceanStory']
 
-    def get_children(self):
+    def get_detail_children(self):
         return OceanStory.objects.child_of(self)
 
 class OceanStory(DetailPageBase):

--- a/portal/ocean_stories/templates/ocean_stories/ocean_stories.html
+++ b/portal/ocean_stories/templates/ocean_stories/ocean_stories.html
@@ -1,5 +1,5 @@
 {% extends "cms/section.html" %}
 
 {% block content %}
-	{% include "portal/components/index_listing.html" with items=self.get_children.live item_template="ocean_stories/ocean_story_card.html" only %}
+	{% include "portal/components/index_listing.html" with items=self.get_detail_children.live item_template="ocean_stories/ocean_story_card.html" only %}
 {% endblock %}


### PR DESCRIPTION
the custom get_children method on OceanStories and DataGaps models
was causing a 500 error when accessing a missing subpath of these.

fixed by renaming the custom method to not conflict.

see https://github.com/torchbox/wagtail/issues/919
