### PR TITLE
add mp_proxy to requirements and hook up to urls

### DIFF
--- a/marco_config/urls.py
+++ b/marco_config/urls.py
@@ -47,6 +47,7 @@ urlpatterns = patterns('',
     url(r'^features/', include('features.urls')),
     url(r'^scenario/', include('scenarios.urls')),
     url(r'^drawing/', include('drawing.urls')),
+    url(r'^proxy/', include('mp_proxy.urls')),
 
     url(r'^images/', include(wagtailimages_urls)),
     url(r'', include(wagtail_urls)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ django-apptemplates==0.0.1
 -e git+git@bitbucket.org:point97/mp-accounts.git@master#egg=mp_accounts-master
 -e git+git@bitbucket.org:point97/mp-visualize.git@master#egg=mp_visualize-master
 -e git+git@bitbucket.org:point97/mp-data-manager.git@master#egg=mp_data_manager-master
+-e git+git@bitbucket.org:point97/mp-proxy.git@master#egg=mp_proxy-master
 -e git+git@bitbucket.org:point97/p97-nursery.git@master#egg=nursery-master


### PR DESCRIPTION
To fix #MP-631 (others?) we need a proxy server. This is implemented as a simple dependency to `mp_proxy` app on bitbucket. 
